### PR TITLE
Rails7.0〜のAPIモードでdeviseを使うと発生するエラーの回避

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::API
         include DeviseTokenAuth::Concerns::SetUserByToken
+        include DeviseHackFakeSession
 end

--- a/app/controllers/concerns/devise_hack_fake_session.rb
+++ b/app/controllers/concerns/devise_hack_fake_session.rb
@@ -1,0 +1,24 @@
+module DeviseHackFakeSession
+  extend ActiveSupport::Concern
+
+  class FakeSession < Hash
+    def enabled?
+      false
+    end
+
+    def destroy
+    end
+  end
+
+  included do
+    before_action :set_fake_session
+
+    private
+
+    def set_fake_session
+      if Rails.configuration.respond_to?(:api_only) && Rails.configuration.api_only
+        request.env['rack.session'] ||= ::DeviseHackFakeSession::FakeSession.new
+      end
+    end
+  end
+end


### PR DESCRIPTION
自分も他で実装した時に発生したのを思い出しましたが、表題の通りRails7系以降のAPIモードで `devise` を利用するとセッションが無効になっている関係のエラーがでる為、下記リンクを参考に微修正しました！

`application.rb` などにセッションを有効するなどしても対応できるようですが、限定的な用途でしか使わないのでこちらの方法をとってプルリクさせていただきます。
あくまでもその場しのぎっぽいので、他に良い方法など見つかれば教えてください！

[Rails 7.0 の api_only = true で devise を使うと DisabledSessionError で落ちるのをなんとかする。](https://blog.dnpp.org/api_only_rails7_with_devise)